### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/marmelab/EventDrops"
   },
   "dependencies": {
-    "d3": "3.4.11"
+    "d3": "3.5.10"
   },
   "devDependencies": {
     "browserify": "5.11.2",


### PR DESCRIPTION
d3 3.4.11 depends jsdom 0.5.7 deps contextify but it's no more needed on node >= 0.12 and may cause error while installing on windows.